### PR TITLE
Security: Add secure flags to auth cookies

### DIFF
--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -5,6 +5,12 @@ import React, { useState, createContext, useContext, ReactNode } from 'react';
 import Cookies from 'js-cookie';
 import { clearBlockedCache } from '../lib/blockApi';
 
+// Secure cookie options for auth tokens
+const secureCookieOptions: Cookies.CookieAttributes = {
+  secure: true,
+  sameSite: 'strict',
+};
+
 interface AuthContextType {
   isLoggedIn: boolean;
   login: (handle: string, appPassword: string) => Promise<boolean>;
@@ -64,13 +70,13 @@ const login = async (
 
     if (response.ok) {
       const data = await response.json();
-      Cookies.set("accessToken", data.accessJwt);
-      Cookies.set("refreshToken", data.refreshJwt);
+      Cookies.set("accessToken", data.accessJwt, secureCookieOptions);
+      Cookies.set("refreshToken", data.refreshJwt, secureCookieOptions);
 
       // Save user info in cookies
-      Cookies.set("userHandle", data.handle);
-      Cookies.set("userDisplayName", data.displayName);
-      Cookies.set("userDID", data.did);
+      Cookies.set("userHandle", data.handle, secureCookieOptions);
+      Cookies.set("userDisplayName", data.displayName, secureCookieOptions);
+      Cookies.set("userDID", data.did, secureCookieOptions);
 
       setUser({
         handle: data.handle,

--- a/src/lib/tokenManager.ts
+++ b/src/lib/tokenManager.ts
@@ -3,6 +3,12 @@ import Cookies from 'js-cookie';
 
 const REFRESH_THRESHOLD_SECONDS = 60; // Refresh if token expires within 60 seconds
 
+// Secure cookie options for auth tokens
+const secureCookieOptions: Cookies.CookieAttributes = {
+  secure: true,
+  sameSite: 'strict',
+};
+
 interface JwtPayload {
   exp?: number;
   iat?: number;
@@ -89,8 +95,8 @@ export const refreshAccessToken = async (refreshToken: string): Promise<RefreshR
     const data: RefreshResponse = await response.json();
 
     // Update cookies with new tokens
-    Cookies.set('accessToken', data.accessJwt);
-    Cookies.set('refreshToken', data.refreshJwt);
+    Cookies.set('accessToken', data.accessJwt, secureCookieOptions);
+    Cookies.set('refreshToken', data.refreshJwt, secureCookieOptions);
 
     console.log('Token refreshed successfully');
     return data;


### PR DESCRIPTION
## Summary
- Fixes #72
- Adds `secure: true` and `sameSite: 'strict'` to all auth cookies

## Changes
- `src/hooks/useAuth.tsx`: Added secureCookieOptions to all Cookies.set() calls
- `src/lib/tokenManager.ts`: Added secureCookieOptions to token refresh

## Security Impact
- Cookies only sent over HTTPS
- CSRF protection via sameSite restriction

🤖 Generated with [Claude Code](https://claude.com/claude-code)