### PR TITLE
Implement batch blocking for massive performance improvement

### DIFF
--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -3,7 +3,7 @@
 
 import React, { useState, createContext, useContext, ReactNode } from 'react';
 import Cookies from 'js-cookie';
-import { clearBlockedCache } from '../lib/blockApi';
+import { clearBlockedCache, clearUserDataCache } from '../lib/blockApi';
 
 // Secure cookie options for auth tokens
 const secureCookieOptions: Cookies.CookieAttributes = {
@@ -116,6 +116,7 @@ const login = async (
     Cookies.remove("userDisplayName");
     Cookies.remove("userDID");
     clearBlockedCache();
+    clearUserDataCache();
   };
 
   return (


### PR DESCRIPTION
## Summary
- **Batch blocking with applyWrites API** - Up to 200 blocks per request instead of 1
- **Removed 50ms sleep** - Was adding 6+ minutes for 7000 users
- **Added caching for user's followers/following** - 10 min TTL, speeds up repeat operations

## Performance Impact
| Scenario | Before | After |
|----------|--------|-------|
| 7000 users | ~10+ minutes | ~30-60 seconds |
| API requests | 7000 | ~35 |
| Sleep time | 350 seconds | ~3.5 seconds |

## Technical Details
- Uses `com.atproto.repo.applyWrites` to batch up to 200 block operations
- Falls back to individual blocking if batch fails (graceful degradation)
- Proper retry logic for 401, 429, and 502 errors
- Caches cleared on logout

## Test plan
- [ ] Test blocking small list (<200 users)
- [ ] Test blocking large list (>200 users)  
- [ ] Verify fallback works when batch fails
- [ ] Verify caches cleared on logout

Closes #77, #78, #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)