### PR TITLE
Performance quick wins: O(n) mutuals, React optimizations, remove dupe fetch

### DIFF
--- a/src/components/SuggestionsList.tsx
+++ b/src/components/SuggestionsList.tsx
@@ -13,7 +13,7 @@ interface SuggestionsListProps {
   onSelect: (suggestion: Suggestion) => void;
 }
 
-export default function SuggestionsList({ suggestions = [], onSelect }: SuggestionsListProps) {
+export default React.memo(function SuggestionsList({ suggestions = [], onSelect }: SuggestionsListProps) {
   // Ensure suggestions has a default empty array if not provided
   if (suggestions.length === 0) {
     return null;
@@ -21,9 +21,9 @@ export default function SuggestionsList({ suggestions = [], onSelect }: Suggesti
 
   return (
     <ul className="rounded bg-white shadow-md max-h-40 overflow-y-auto w-full max-w-md">
-      {suggestions.map((suggestion, index) => (
+      {suggestions.map((suggestion) => (
         <li
-          key={index}
+          key={suggestion.handle}
           onClick={() => onSelect(suggestion)}
           className="flex items-center px-4 py-2 cursor-pointer hover:bg-gray-200"
         >
@@ -46,4 +46,4 @@ export default function SuggestionsList({ suggestions = [], onSelect }: Suggesti
       ))}
     </ul>
   );
-}
+});

--- a/src/components/UserBlocker.tsx
+++ b/src/components/UserBlocker.tsx
@@ -139,7 +139,7 @@ const handleLogin = async () => {
       <SuggestionsList suggestions={suggestions} onSelect={selectSuggestion} />
       {userProfile && (
         <UserProfileDisplay
-          handle={userProfile.handle}
+          userProfile={userProfile}
           isLoggedIn={isLoggedIn}
           onBlockFollowers={handleBlockFollowers}
           onBlockFollows={handleBlockFollows}

--- a/src/components/UserProfileDisplay.tsx
+++ b/src/components/UserProfileDisplay.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useMemo } from "react";
 import { useAuth } from "../hooks/useAuth";
-import { getProfile } from "../lib/actorApi";
 import { Badge } from "../components/ui/badge";
 import { Button } from "../components/ui/button";
 import HelpSheet from "./HelpSheet";
@@ -29,7 +28,7 @@ interface UserProfile {
 }
 
 interface UserProfileDisplayProps {
-  handle: string;
+  userProfile: UserProfile;
   onBlockFollowers: () => Promise<void>;
   onBlockFollows: () => Promise<void>;
   isLoggedIn: boolean;
@@ -47,7 +46,7 @@ interface UserProfileDisplayProps {
 }
 
 export default function UserProfileDisplay({
-  handle,
+  userProfile,
   onBlockFollowers,
   onBlockFollows,
   isLoggedIn,
@@ -64,27 +63,20 @@ export default function UserProfileDisplay({
   alreadyBlockedCount,
 }: UserProfileDisplayProps) {
   const [hydrated, setHydrated] = useState(false);
-  const [userProfile, setUserProfile] = useState<UserProfile | null>(null);
   const [accountHandle, setAccountHandle] = useState("");
   const [appPassword, setAppPassword] = useState("");
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
   const { login, logout, errorMessage } = useAuth();
-  const randomText = getRandomShareText();
-  const shareLink = `https://bsky.app/intent/compose?text=${randomText}`;
 
+  // Memoize share link to avoid recalculating on every render
+  const shareLink = useMemo(() => {
+    const randomText = getRandomShareText();
+    return `https://bsky.app/intent/compose?text=${randomText}`;
+  }, []);
 
   useEffect(() => {
     setHydrated(true);
   }, []);
-
-  useEffect(() => {
-    async function loadProfile() {
-      if (!handle) return;
-      const profile = await getProfile(handle);
-      setUserProfile(profile);
-    }
-    loadProfile();
-  }, [handle]);
 
   const handleLogin = async () => {
     await login(accountHandle, appPassword);


### PR DESCRIPTION
## Summary
Low-risk, high-impact performance improvements.

### 1. Fix O(n³) → O(n) in `identifyMutuals()`
**Before:**
```typescript
return list.filter((item) =>
  userFollowers.some(...) &&  // O(n)
  userFollows.some(...)       // O(n)
);
// Total: O(n³) for large lists
```

**After:**
```typescript
const followerHandles = new Set(userFollowers.map(f => f.handle));
const followingHandles = new Set(userFollows.map(f => f.handle));
return list.filter((item) =>
  followerHandles.has(item.handle) && followingHandles.has(item.handle)
);
// Total: O(n)
```

For a user with 5,000 followers blocking 8,000 targets, this is **massive**.

### 2. Token Header Caching (30s TTL)
- `updateAuthAgentHeader()` was called before every batch operation
- Now caches the result for 30 seconds
- Avoids redundant `getValidAccessToken()` calls

### 3. React Key Fix in SuggestionsList
- Changed from `key={index}` to `key={suggestion.handle}`
- Wrapped component in `React.memo()`
- Prevents unnecessary re-renders during autocomplete

### 4. Remove Duplicate Profile Fetch
- `UserProfileDisplay` was fetching profile internally even though parent already had it
- Now accepts `userProfile` as prop instead of `handle`
- Eliminates redundant API call on every profile view
- Also memoized `shareLink` generation with `useMemo()`

## Test plan
- [ ] Test autocomplete suggestions (should feel snappier)
- [ ] Test blocking operation on account with many followers
- [ ] Verify profile displays correctly after selecting from suggestions

🤖 Generated with [Claude Code](https://claude.com/claude-code)