### PR TITLE
Improve Block Following UX and add colored toasts

### DIFF
--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -24,6 +24,14 @@ const Toaster = ({ ...props }: ToasterProps) => {
         error: <OctagonXIcon className="size-4" />,
         loading: <Loader2Icon className="size-4 animate-spin" />,
       }}
+      toastOptions={{
+        classNames: {
+          success: '!bg-green-600 !border-green-700 !text-white [&_svg]:!text-white',
+          error: '!bg-red-600 !border-red-700 !text-white [&_svg]:!text-white',
+          info: '!bg-blue-600 !border-blue-700 !text-white [&_svg]:!text-white',
+          warning: '!bg-amber-500 !border-amber-600 !text-white [&_svg]:!text-white',
+        },
+      }}
       style={
         {
           "--normal-bg": "var(--popover)",

--- a/src/routes/auth/callback.tsx
+++ b/src/routes/auth/callback.tsx
@@ -30,7 +30,7 @@ export const Route = createFileRoute('/auth/callback')({
       if (result.success) {
         // Redirect immediately to prevent client-side re-execution
         // Include login=oauth param so home page can track login_success
-        throw redirect({ to: '/', search: { login: 'oauth' } })
+        throw redirect({ to: '/', search: { login: 'oauth', error: undefined } })
       }
 
       return result

--- a/src/routes/auth/login.tsx
+++ b/src/routes/auth/login.tsx
@@ -13,7 +13,7 @@ export const Route = createFileRoute('/auth/login')({
 
     if (!handle) {
       console.log('[OAuth Login] No handle, redirecting to /')
-      throw redirect({ to: '/', search: { error: undefined } })
+      throw redirect({ to: '/', search: { error: undefined, login: undefined } })
     }
 
     try {
@@ -21,7 +21,7 @@ export const Route = createFileRoute('/auth/login')({
       const HANDLE_REGEX = /^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$/
       if (!HANDLE_REGEX.test(handle)) {
         console.error('[OAuth Login] Invalid handle format')
-        throw redirect({ to: '/', search: { error: 'invalid_handle' } })
+        throw redirect({ to: '/', search: { error: 'invalid_handle', login: undefined } })
       }
 
       console.log('[OAuth Login] Getting OAuth client...')
@@ -45,7 +45,7 @@ export const Route = createFileRoute('/auth/login')({
       }
 
       console.error('[OAuth Login] Error:', error)
-      throw redirect({ to: '/', search: { error: 'login_failed' } })
+      throw redirect({ to: '/', search: { error: 'login_failed', login: undefined } })
     }
   },
 


### PR DESCRIPTION
## Summary
- **Confirmation dialog** for "Block Following" — warns users this blocks accounts the target *follows* (not their followers), which may include popular/unrelated accounts. Shows count and reminds mutuals are protected.
- **Button subtitles** — "People who follow @handle" and "Accounts followed by @handle" to differentiate the two actions at a glance.
- **"Also block @handle" toggle** — defaults on, lets users block the target account alongside their network. Shows green check if already blocked (with tooltip). Hidden when targeting yourself.
- **Colored toast backgrounds** — success (green), error (red), info (blue), warning (amber) so toasts pop visually.
- **TS error fix** — auth redirects now include both search params to satisfy type checker.

## Test plan
- [ ] Click "Block Following" → dialog appears with warning and count
- [ ] Click "Cancel" → dialog closes, no blocking
- [ ] Click "Block Following" in dialog → blocking proceeds normally
- [ ] Click "Block Followers" → no dialog, immediate (unchanged)
- [ ] "Also block @handle" toggle defaults to checked (green circle-check)
- [ ] Click toggle → unchecks (shows circle-xmark), re-click → re-checks
- [ ] If target already blocked → green check with "already blocked" text and tooltip
- [ ] If targeting yourself → toggle hidden entirely
- [ ] After completing one type, remaining "Block Following" button still shows dialog
- [ ] Toasts show colored backgrounds (trigger success/error to verify)
- [ ] Responsive: dialog and buttons work on mobile

Closes #89